### PR TITLE
Added Bottom Navigation Widget (Krishna)

### DIFF
--- a/lib/widgets/bottomNav_Krishna.dart
+++ b/lib/widgets/bottomNav_Krishna.dart
@@ -8,57 +8,9 @@ class BottomNavKrishna extends StatefulWidget {
 }
 
 class _BottomNavKrishnaState extends State<BottomNavKrishna> {
-  // 1. Variable to track which tab is currently selected (0, 1, or 2)
   int _selectedIndex = 0;
 
-  // 2. The List of "Placeholder" screens to show
-  // (In a real app, these would be separate Screen widgets like HomeScreen(), MenuScreen(), etc.)
-  static const List<Widget> _pages = <Widget>[
-    // Tab 0: Home
-    Center(
-      child: Column(
-        mainAxisAlignment: MainAxisAlignment.center,
-        children: [
-          Icon(Icons.home_rounded, size: 64, color: Colors.blueAccent),
-          SizedBox(height: 16),
-          Text(
-            "Home Feed",
-            style: TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
-          ),
-        ],
-      ),
-    ),
-    // Tab 1: Menu
-    Center(
-      child: Column(
-        mainAxisAlignment: MainAxisAlignment.center,
-        children: [
-          Icon(Icons.restaurant_menu_rounded, size: 64, color: Colors.orange),
-          SizedBox(height: 16),
-          Text(
-            "Mess Menu",
-            style: TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
-          ),
-        ],
-      ),
-    ),
-    // Tab 2: Profile
-    Center(
-      child: Column(
-        mainAxisAlignment: MainAxisAlignment.center,
-        children: [
-          Icon(Icons.person_rounded, size: 64, color: Colors.purple),
-          SizedBox(height: 16),
-          Text(
-            "Student Profile",
-            style: TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
-          ),
-        ],
-      ),
-    ),
-  ];
-
-  // 3. Function to handle tap events
+  // Function to handle tap events
   void _onItemTapped(int index) {
     setState(() {
       _selectedIndex = index;
@@ -68,8 +20,59 @@ class _BottomNavKrishnaState extends State<BottomNavKrishna> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      // The Body changes based on _selectedIndex
-      body: _pages[_selectedIndex],
+      // IndexedStack keeps all children in the tree but only paints the one at 'index'.
+      // This preserves the state (scroll position, text inputs) of the other pages.
+      body: IndexedStack(
+        index: _selectedIndex,
+        children: const [
+          // Tab 0: Home
+          Center(
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                Icon(Icons.home_rounded, size: 64, color: Colors.blueAccent),
+                SizedBox(height: 16),
+                Text(
+                  "Home Feed",
+                  style: TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
+                ),
+              ],
+            ),
+          ),
+          // Tab 1: Menu
+          Center(
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                Icon(
+                  Icons.restaurant_menu_rounded,
+                  size: 64,
+                  color: Colors.orange,
+                ),
+                SizedBox(height: 16),
+                Text(
+                  "Mess Menu",
+                  style: TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
+                ),
+              ],
+            ),
+          ),
+          // Tab 2: Profile
+          Center(
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                Icon(Icons.person_rounded, size: 64, color: Colors.purple),
+                SizedBox(height: 16),
+                Text(
+                  "Student Profile",
+                  style: TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
 
       // The Navigation Bar at the bottom
       bottomNavigationBar: NavigationBar(
@@ -77,8 +80,7 @@ class _BottomNavKrishnaState extends State<BottomNavKrishna> {
         onDestinationSelected: _onItemTapped,
         elevation: 3.0,
         backgroundColor: Colors.white,
-        indicatorColor:
-            Colors.blue.shade100, // The "Pill" color behind selected icon
+        indicatorColor: Colors.blue.shade100,
         destinations: const <NavigationDestination>[
           NavigationDestination(
             icon: Icon(Icons.home_outlined),


### PR DESCRIPTION
## Issue: #43 

Implemented a responsive Bottom Navigation Bar using Material 3 `NavigationBar`.

### Changes Implemented:
- Created `BottomNavKrishna` widget with Home, Menu, and Profile tabs.
- **Refactored to use `IndexedStack`**: This ensures that the state of each tab (like scroll position or text inputs) is preserved when switching between them, avoiding unnecessary rebuilds.
- Removed static page lists to allow better integration with `context` and state management in the future.

### Screenshots:
<img width="1920" height="1020" alt="NomMetric - Google Chrome 02-01-2026 13_35_07" src="https://github.com/user-attachments/assets/47359360-27c9-440e-a1a3-25b9b5ff4e1a" />

<img width="1920" height="1020" alt="NomMetric - Google Chrome 02-01-2026 13_35_12" src="https://github.com/user-attachments/assets/1c1cea21-5e0b-4ca6-83d1-87daa1a1808b" />

<img width="1920" height="1020" alt="NomMetric - Google Chrome 02-01-2026 13_35_14" src="https://github.com/user-attachments/assets/ff0b64f4-930d-404e-ab71-965edb0f17ff" />