### PR TITLE
Added reusable bottom navigation widget

### DIFF
--- a/lib/widgets/bottomNav_Savan.dart
+++ b/lib/widgets/bottomNav_Savan.dart
@@ -1,0 +1,37 @@
+import 'package:flutter/material.dart';
+
+class BottomNavSavan extends StatelessWidget {
+  final int currentIndex;
+  final ValueChanged<int> onTap;
+
+  const BottomNavSavan({
+    Key? key,
+    required this.currentIndex,
+    required this.onTap,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return BottomNavigationBar(
+      currentIndex: currentIndex,
+      type: BottomNavigationBarType.fixed,
+      selectedItemColor: Colors.blue,
+      unselectedItemColor: Colors.grey,
+      onTap: onTap,
+      items: const [
+        BottomNavigationBarItem(
+          icon: Icon(Icons.home),
+          label: 'Home',
+        ),
+        BottomNavigationBarItem(
+          icon: Icon(Icons.menu),
+          label: 'Menu',
+        ),
+        BottomNavigationBarItem(
+          icon: Icon(Icons.person),
+          label: 'Profile',
+        ),
+      ],
+    );
+  }
+}


### PR DESCRIPTION
Issue:#43

Added a reusable Bottom Navigation widget with Home, Menu, and Profile tabs.

- Implemented as a reusable widget (not a full screen)

Screenshot attached below.

<img width="1470" height="956" alt="Screenshot 2026-01-16 at 3 50 19 PM" src="https://github.com/user-attachments/assets/4cfbfabd-2d06-4af5-be52-7390df223e49" />
<img width="1470" height="956" alt="Screenshot 2026-01-16 at 3 50 28 PM" src="https://github.com/user-attachments/assets/babc2d5b-6d93-447e-867f-796937d1fe9b" />
<img width="1470" height="956" alt="Screenshot 2026-01-16 at 3 50 36 PM" src="https://github.com/user-attachments/assets/1da395ae-80cb-492f-a372-3cc778355bf3" />
