### PR TITLE
Issue:#12 Add reusable status card widget

### DIFF
--- a/lib/widgets/statusCard_savan.dart
+++ b/lib/widgets/statusCard_savan.dart
@@ -1,0 +1,126 @@
+import 'package:flutter/material.dart';
+
+class StatusCardSavan extends StatelessWidget {
+  final IconData icon;
+  final String title;
+  final String message;
+  final Color statusColor;
+  final String? actionText;
+  final VoidCallback? onActionTap;
+  final VoidCallback? onCardTap; 
+
+  const StatusCardSavan({
+    super.key,
+    required this.icon,
+    required this.title,
+    required this.message,
+    required this.statusColor,
+    this.actionText,
+    this.onActionTap,
+    this.onCardTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      margin: const EdgeInsets.only(bottom: 16), 
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(20),
+        boxShadow: [
+          BoxShadow(
+            color: statusColor.withOpacity(0.15),
+            offset: const Offset(0, 8),
+            blurRadius: 20,
+            spreadRadius: -5,
+          ),
+          BoxShadow(
+            color: Colors.black.withOpacity(0.05), 
+            offset: const Offset(0, 4),
+            blurRadius: 10,
+          ),
+        ],
+      ),
+      child: Material(
+        color: Colors.transparent,
+        child: InkWell(
+          borderRadius: BorderRadius.circular(20),
+          onTap: onCardTap,
+          child: Padding(
+            padding: const EdgeInsets.all(20),
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+
+                // 1. Icon in a tinted container
+                Container(
+                  padding: const EdgeInsets.all(12),
+                  decoration: BoxDecoration(
+                    color: statusColor.withOpacity(0.1),
+                    shape: BoxShape.circle,
+                  ),
+                  child: Icon(icon, color: statusColor, size: 28),
+                ),
+                const SizedBox(width: 16),
+                
+                // 2. Text Content
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        title,
+                        style: const TextStyle(
+                          fontSize: 16,
+                          fontWeight: FontWeight.bold,
+                          color: Colors.black87,
+                          letterSpacing: 0.5,
+                        ),
+                      ),
+                      const SizedBox(height: 6),
+                      Text(
+                        message,
+                        style: TextStyle(
+                          fontSize: 14,
+                          height: 1.4, 
+                          color: Colors.grey.shade600,
+                        ),
+                      ),
+                      
+                      // 3. Action Button 
+                      if (actionText != null) ...[
+                        const SizedBox(height: 16),
+                        InkWell(
+                          onTap: onActionTap,
+                          borderRadius: BorderRadius.circular(50),
+                          child: Container(
+                            padding: const EdgeInsets.symmetric(
+                                horizontal: 16, vertical: 8),
+                            decoration: BoxDecoration(
+                              color: statusColor.withOpacity(0.1),
+                              borderRadius: BorderRadius.circular(50),
+                              border: Border.all(
+                                  color: statusColor.withOpacity(0.2)),
+                            ),
+                            child: Text(
+                              actionText!,
+                              style: TextStyle(
+                                color: statusColor,
+                                fontWeight: FontWeight.w600,
+                                fontSize: 13,
+                              ),
+                            ),
+                          ),
+                        ),
+                      ]
+                    ],
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
Issue: #115 

Added reusable status / notification card widget.

- Stateless and UI-only  
- Icon, Title, Message  
- Optional action button  
- Status color  

Screenshot attached below.
<img width="1470" height="956" alt="Screenshot 2026-01-17 at 12 02 41 PM" src="https://github.com/user-attachments/assets/ca47ced2-7321-431f-9bdc-b99f05c5b358" />
