### PR TITLE
Issue:#6 Add bottom navigation skeleton widget

### DIFF
--- a/lib/widgets/bottomNav_hassan.dart
+++ b/lib/widgets/bottomNav_hassan.dart
@@ -1,0 +1,94 @@
+import 'package:flutter/material.dart';
+
+class BottomNavHassan extends StatefulWidget {
+  const BottomNavHassan({Key? key}) : super(key: key);
+
+  @override
+  State<BottomNavHassan> createState() => _BottomNavHassanState();
+}
+
+class _BottomNavHassanState extends State<BottomNavHassan> {
+  int _currentIndex = 0;
+
+  final List<Widget> _screens = const [
+    _HomePlaceholder(),
+    _MenuPlaceholder(),
+    _ProfilePlaceholder(),
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: IndexedStack(
+        index: _currentIndex,
+        children: _screens,
+      ),
+      bottomNavigationBar: BottomNavigationBar(
+        currentIndex: _currentIndex,
+        onTap: (index) {
+          setState(() {
+            _currentIndex = index;
+          });
+        },
+        items: const [
+          BottomNavigationBarItem(
+            icon: Icon(Icons.home_outlined),
+            label: 'Home',
+          ),
+          BottomNavigationBarItem(
+            icon: Icon(Icons.restaurant_menu_outlined),
+            label: 'Menu',
+          ),
+          BottomNavigationBarItem(
+            icon: Icon(Icons.person_outline),
+            label: 'Profile',
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/* ---------------- Placeholder Screens ---------------- */
+
+class _HomePlaceholder extends StatelessWidget {
+  const _HomePlaceholder();
+
+  @override
+  Widget build(BuildContext context) {
+    return const Center(
+      child: Text(
+        'Home Screen',
+        style: TextStyle(fontSize: 20, fontWeight: FontWeight.w600),
+      ),
+    );
+  }
+}
+
+class _MenuPlaceholder extends StatelessWidget {
+  const _MenuPlaceholder();
+
+  @override
+  Widget build(BuildContext context) {
+    return const Center(
+      child: Text(
+        'Menu Screen',
+        style: TextStyle(fontSize: 20, fontWeight: FontWeight.w600),
+      ),
+    );
+  }
+}
+
+class _ProfilePlaceholder extends StatelessWidget {
+  const _ProfilePlaceholder();
+
+  @override
+  Widget build(BuildContext context) {
+    return const Center(
+      child: Text(
+        'Profile Screen',
+        style: TextStyle(fontSize: 20, fontWeight: FontWeight.w600),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
Issue:#43

Added a reusable Bottom Navigation widget with three tabs:
- Home
- Menu
- Profile

Each tab switches between placeholder screens.
No changes were made to main.dart or backend logic.

Screenshot attached.
<img width="358" height="767" alt="Screenshot 2026-01-25 125804" src="https://github.com/user-attachments/assets/230a8eae-f9ef-494f-8a52-910af8bbf0e1" />
