### PR TITLE
feat: add bottom navigation skeleton

### DIFF
--- a/lib/widgets/bottomNav_rabia.dart
+++ b/lib/widgets/bottomNav_rabia.dart
@@ -1,0 +1,38 @@
+import 'package:flutter/material.dart';
+
+class BottomNavRabia extends StatefulWidget {
+  const BottomNavRabia({Key? key}) : super(key: key);
+
+  @override
+  State<BottomNavRabia> createState() => _BottomNavRabiaState();
+}
+
+class _BottomNavRabiaState extends State<BottomNavRabia> {
+  int _currentIndex = 0;
+
+  final List<Widget> _screens = const [
+    Center(child: Text('Home Screen', style: TextStyle(fontSize: 20))),
+    Center(child: Text('Menu Screen', style: TextStyle(fontSize: 20))),
+    Center(child: Text('Profile Screen', style: TextStyle(fontSize: 20))),
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: _screens[_currentIndex],
+      bottomNavigationBar: BottomNavigationBar(
+        currentIndex: _currentIndex,
+        onTap: (index) {
+          setState(() {
+            _currentIndex = index;
+          });
+        },
+        items: const [
+          BottomNavigationBarItem(icon: Icon(Icons.home), label: 'Home'),
+          BottomNavigationBarItem(icon: Icon(Icons.menu), label: 'Menu'),
+          BottomNavigationBarItem(icon: Icon(Icons.person), label: 'Profile'),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
Issue : #144
- Added bottom navigation bar skeleton
- Implemented Home, Menu, and Profile tabs
- Used StatefulWidget to handle tab switching

Screenshots:
- Attached in comment

Checklist:
- [x] Code follows project style
- [x] No breaking changes
- [x] Tested locally

<img width="188" height="388" alt="screenshot" src="https://github.com/user-attachments/assets/28121043-eabc-4ec7-b302-56c03eea10b3" />
