### PR TITLE
Issue #13: Add reusable SectionHeader widget

### DIFF
--- a/lib/widgets/sectionHeader_savan.dart
+++ b/lib/widgets/sectionHeader_savan.dart
@@ -1,0 +1,170 @@
+import 'package:flutter/material.dart';
+
+class SectionHeader extends StatelessWidget {
+  final String title;
+  final String? subtitle;
+  final Color baseColor;
+  final String? actionLabel;
+  final IconData? actionIcon;
+  final VoidCallback? onActionTap;
+
+  const SectionHeader({
+    super.key,
+    required this.title,
+    required this.baseColor,
+    this.subtitle,
+    this.actionLabel,
+    this.actionIcon,
+    this.onActionTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final glowColor = baseColor.withOpacity(0.2);
+    final cardBg = baseColor.withOpacity(0.04);
+    final borderColor = baseColor.withOpacity(0.1);
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Padding(
+            padding: const EdgeInsets.only(bottom: 14.0),
+            child: IntrinsicHeight(
+              child: Row(
+                crossAxisAlignment: CrossAxisAlignment.center,
+                children: [
+                  Container(
+                    width: 6,
+                    height: 32,
+                    decoration: BoxDecoration(
+                      color: baseColor,
+                      borderRadius: BorderRadius.circular(4),
+                      boxShadow: [
+                        BoxShadow(
+                          color: baseColor.withOpacity(0.4),
+                          blurRadius: 6,
+                          offset: const Offset(1, 1),
+                        )
+                      ],
+                    ),
+                  ),
+                  const SizedBox(width: 12),
+                  Expanded(
+                    child: Text(
+                      title,
+                      style: const TextStyle(
+                        fontSize: 24,
+                        fontWeight: FontWeight.w900,
+                        letterSpacing: -0.5,
+                        color: Colors.black87,
+                      ),
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+          Container(
+            width: double.infinity,
+            decoration: BoxDecoration(
+              color: Colors.white,
+              borderRadius: BorderRadius.circular(28),
+              border: Border.all(color: borderColor, width: 1.5),
+              boxShadow: [
+                BoxShadow(
+                  color: glowColor,
+                  blurRadius: 24,
+                  spreadRadius: 0,
+                  offset: const Offset(0, 10),
+                ),
+              ],
+            ),
+            child: Container(
+              decoration: BoxDecoration(
+                color: cardBg,
+                borderRadius: BorderRadius.circular(28),
+              ),
+              padding: const EdgeInsets.all(24.0),
+              child: Row(
+                children: [
+                  Expanded(
+                    child: Text(
+                      subtitle ?? "View details",
+                      style: TextStyle(
+                        fontSize: 15,
+                        fontWeight: FontWeight.w600,
+                        color: Colors.black.withOpacity(0.7),
+                        height: 1.3,
+                      ),
+                      maxLines: 2,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  ),
+                  if (actionLabel != null || actionIcon != null) ...[
+                    const SizedBox(width: 16),
+                    Material(
+                      color: Colors.white,
+                      borderRadius: BorderRadius.circular(16),
+                      elevation: 0,
+                      child: InkWell(
+                        onTap: onActionTap,
+                        borderRadius: BorderRadius.circular(16),
+                        child: Container(
+                          padding: const EdgeInsets.symmetric(
+                            horizontal: 16,
+                            vertical: 12,
+                          ),
+                          decoration: BoxDecoration(
+                            borderRadius: BorderRadius.circular(16),
+                            border: Border.all(
+                              color: Colors.black.withOpacity(0.05),
+                              width: 1,
+                            ),
+                            boxShadow: [
+                              BoxShadow(
+                                color: Colors.black.withOpacity(0.04),
+                                blurRadius: 4,
+                                offset: const Offset(0, 2),
+                              )
+                            ],
+                          ),
+                          child: Row(
+                            mainAxisSize: MainAxisSize.min,
+                            children: [
+                              if (actionLabel != null)
+                                Text(
+                                  actionLabel!,
+                                  style: TextStyle(
+                                    fontSize: 13,
+                                    fontWeight: FontWeight.w800,
+                                    color: baseColor,
+                                  ),
+                                ),
+                              if (actionIcon != null) ...[
+                                if (actionLabel != null)
+                                  const SizedBox(width: 8),
+                                Icon(
+                                  actionIcon,
+                                  size: 16,
+                                  color: baseColor,
+                                ),
+                              ],
+                            ],
+                          ),
+                        ),
+                      ),
+                    ),
+                  ],
+                ],
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
Issue: #136 

### ✨ SectionHeader Widget Added

- Added reusable SectionHeader widget inside lib/widgets/
- Supports title, subtitle, and optional action button (text/icon)
- Fully configurable via constructor parameters
- Clean UI and reusable design
- No screen or backend changes done

### 📸 Screenshot
<img width="1470" height="956" alt="Section Header ss" src="https://github.com/user-attachments/assets/38874bb5-0413-4198-98a3-d98c00a28925" />



